### PR TITLE
[SAP] allow all shards of an AZ to access an object

### DIFF
--- a/kmip/core/utils.py
+++ b/kmip/core/utils.py
@@ -15,6 +15,7 @@
 
 from binascii import hexlify
 import io
+import re
 
 from kmip.core import exceptions
 
@@ -60,6 +61,25 @@ def build_er_error(class_object, descriptor, expected, received,
         class_string = '{0}.{1}'.format(class_object.__name__, attribute)
 
     return msg.format(class_string, descriptor, expected, received)
+
+
+def match_owner(session_user, object_owner):
+    """
+    Allows all shards of an AZ to access an object, by matching
+    the vCenter hostname AZ and region.
+    """
+    def extract_vcenter_az(hostname):
+        if hostname:
+            match = re.search(
+                r'^vc-([a-z])-\d+\.cc\.(.+)\.cloud\.sap$',
+                hostname)
+            if match:
+                return match.group(1, 2)
+        return hostname
+
+    user_az = extract_vcenter_az(session_user)
+    owner_az = extract_vcenter_az(object_owner)
+    return user_az == owner_az
 
 
 class BytearrayStream(io.RawIOBase):

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -29,6 +29,7 @@ import kmip
 from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import exceptions
+from kmip.core import utils
 
 from kmip.core.objects import MACData, KeyWrappingData
 
@@ -1166,7 +1167,7 @@ class KmipEngine(object):
         if operation_object_policy == enums.Policy.ALLOW_ALL:
             return True
         elif operation_object_policy == enums.Policy.ALLOW_OWNER:
-            if session_user == object_owner:
+            if utils.match_owner(session_user, object_owner):
                 return True
             else:
                 return False

--- a/kmip/tests/unit/core/test_utils.py
+++ b/kmip/tests/unit/core/test_utils.py
@@ -54,6 +54,32 @@ class TestUtils(TestCase):
                          'received {2} byte(s)'.format(num, bytes_exp,
                                                        bytes_obs))
 
+    def test_match_owner(self):
+        # Correctly matches vCenter owners
+        self.assertTrue(
+            utils.match_owner('vc-a-0.cc.qa-de-1.cloud.sap',
+                              'vc-a-1.cc.qa-de-1.cloud.sap')
+        )
+        self.assertFalse(
+            utils.match_owner('vc-a-0.cc.qa-de-1.cloud.sap',
+                              'vc-b-0.cc.qa-de-1.cloud.sap')
+        )
+        self.assertFalse(
+            utils.match_owner('vc-a-0.cc.qa-de-1.cloud.sap',
+                              'vc-a-0.cc.eu-de-1.cloud.sap')
+        )
+
+        # Usual owners
+        self.assertTrue(
+            utils.match_owner('owner1', 'owner1')
+        )
+        self.assertTrue(
+            utils.match_owner(None, None)
+        )
+        self.assertFalse(
+            utils.match_owner('owner2', 'owner1')
+        )
+
 
 class TestBytearrayStream(TestCase):
 


### PR DESCRIPTION
Use regex-based matching when checking the ownership so that all vCenters of an AZ can access that object.

This is needed because there are some discrepancies of ownership when nova/cinder are coordinating VM/volumes migrations across different vCenters.