### PR TITLE
Potential fix for code scanning alert no. 12: Use of insecure SSL/TLS version

### DIFF
--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -286,6 +286,7 @@ class KMIPProxy(object):
 
     def _create_socket(self, sock):
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.check_hostname = False
         context.set_ciphers('ECDHE-ECDSA-AES256-SHA384,AES256-SHA256')
         context.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/12](https://github.com/sapcc/PyKMIP/security/code-scanning/12)

To fix the issue, we will explicitly set the `minimum_version` attribute of the `SSLContext` object to `ssl.TLSVersion.TLSv1_2`. This ensures that only TLS 1.2 and higher are allowed, regardless of the system's default configuration. This change will be made in the `_create_socket` method where the `SSLContext` is initialized.

Steps:
1. Add `context.minimum_version = ssl.TLSVersion.TLSv1_2` after the `ssl.SSLContext` initialization on line 288.
2. Ensure that the fix does not alter the existing functionality of the `_create_socket` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
