### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -729,7 +729,7 @@ def log_secret(logger, secret_type, secret_value):
     elif secret_type is ObjectType.SPLIT_KEY:
         log_split_key(logger, secret_value)
     else:
-        logger.info('generic secret: {0}'.format(secret_value))
+        logger.info('generic secret: [REDACTED]')
 
 
 def log_certificate(logger, certificate):


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/11](https://github.com/sapcc/PyKMIP/security/code-scanning/11)

To fix the issue, sensitive data should not be logged in clear text. Instead, the `log_secret` function should mask or sanitize the `secret_value` before logging it. For example:
1. Replace the logging of `secret_value` with a generic message indicating that a secret was processed, without revealing its content.
2. Alternatively, if logging the content is necessary for debugging, ensure that sensitive parts of the data are masked (e.g., replacing characters with asterisks).

The fix will involve modifying the `log_secret` function in `kmip/demos/utils.py` to handle the generic case (`else` block) securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
