### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/kmip/demos/pie/get.py
+++ b/kmip/demos/pie/get.py
@@ -45,6 +45,6 @@ if __name__ == '__main__':
             secret = client.get(uid)
             logger.info("Successfully retrieved secret with ID: {0}".format(
                 uid))
-            logger.info("Secret data: {0}".format(secret))
+            logger.info("Secret retrieved successfully but its contents are not logged for security reasons.")
         except Exception as e:
             logger.error(e)


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/10](https://github.com/sapcc/PyKMIP/security/code-scanning/10)

To fix the issue, we should avoid logging the sensitive data (`secret`) directly. Instead, we can log a generic success message or metadata that does not expose sensitive information. For example, we can log the UUID (`uid`) to indicate which secret was retrieved without revealing its contents. This ensures that sensitive data is not exposed while still providing useful information for debugging or auditing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
