### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/pykmip-restapi/routes/kmip_routes.py
+++ b/pykmip-restapi/routes/kmip_routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, request, jsonify
 from services.kmip_service import KMIPService
+import logging
 
 class KMIPRoutes:
     def __init__(self, kmip_service):
@@ -59,7 +60,6 @@ class KMIPRoutes:
             }), 200
 
         except Exception as e:
-            import logging
             logging.error("An unexpected error occurred", exc_info=True)
             return jsonify({"error": "An internal error has occurred. Please contact support."}), 500
 
@@ -122,6 +122,5 @@ class KMIPRoutes:
             }), 200
 
         except Exception as e:
-            import logging
             logging.error("An unexpected error occurred", exc_info=True)
             return jsonify({"error": "An internal error has occurred. Please contact support."}), 500

--- a/pykmip-restapi/routes/kmip_routes.py
+++ b/pykmip-restapi/routes/kmip_routes.py
@@ -59,7 +59,9 @@ class KMIPRoutes:
             }), 200
 
         except Exception as e:
-            return jsonify({"error": f"An unexpected error occurred: {str(e)}"}), 500
+            import logging
+            logging.error("An unexpected error occurred", exc_info=True)
+            return jsonify({"error": "An internal error has occurred. Please contact support."}), 500
 
     def register_kmip(self):
         """
@@ -120,4 +122,6 @@ class KMIPRoutes:
             }), 200
 
         except Exception as e:
-            return jsonify({"error": f"An unexpected error occurred: {str(e)}"}), 500
+            import logging
+            logging.error("An unexpected error occurred", exc_info=True)
+            return jsonify({"error": "An internal error has occurred. Please contact support."}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/1](https://github.com/sapcc/PyKMIP/security/code-scanning/1)

To fix the issue, we need to ensure that sensitive information from exceptions is not exposed to external users. Instead of including the exception message (`str(e)`) in the response, we should log the exception details on the server for debugging purposes and return a generic error message to the user. This approach aligns with the "GOOD" example in the background section.

Steps to implement the fix:
1. Replace the line that returns the exception message in the JSON response with a generic error message.
2. Log the exception details (including the stack trace) on the server using a logging mechanism.
3. Ensure that the logging library is imported and properly configured if not already done.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
