### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/pykmip-restapi/services/barbican_service.py
+++ b/pykmip-restapi/services/barbican_service.py
@@ -93,7 +93,7 @@ class BarbicanService:
 
             # Find the project_id using the external_id
             find_project_query = "SELECT id FROM projects WHERE external_id=%s"
-            logger.debug(f"Executing query: {find_project_query} with external_id={external_id}")
+            logger.debug("Executing find query for projects table with placeholders for sensitive data.")
             cursor.execute(find_project_query, (external_id,))
             project = cursor.fetchone()
 
@@ -106,7 +106,7 @@ class BarbicanService:
 
             # Update the project_id in the secrets table
             update_query = "UPDATE secrets SET project_id=%s WHERE id=%s"
-            logger.debug(f"Executing query: {update_query} with project_id={project_id}, secret_id={secret_id}")
+            logger.debug("Executing update query for secrets table with placeholders for sensitive data.")
             cursor.execute(update_query, (project_id, secret_id))
 
             if cursor.rowcount == 0:


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/3](https://github.com/sapcc/PyKMIP/security/code-scanning/3)

To fix the issue, we will sanitize the log message to avoid including sensitive data like `secret_id` and `project_id`. Instead of logging the full query with sensitive parameters, we will log a generic message indicating the query execution without exposing the actual values. This ensures that sensitive data is not written to the logs while still providing useful debugging information.

Changes will be made to the log messages on line 109 and similar cases (e.g., line 96) to remove sensitive data. We will replace the sensitive values with placeholders or omit them entirely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
