### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/pykmip-restapi/services/barbican_service.py
+++ b/pykmip-restapi/services/barbican_service.py
@@ -114,7 +114,7 @@ class BarbicanService:
 
             # Commit the transaction
             self.connection.commit()
-            logger.info(f"Project ID updated successfully for secret_id={secret_id}")
+            logger.info("Project ID updated successfully for a secret.")
 
             return {"message": "Project ID updated successfully"}
         except Error as e:


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/4](https://github.com/sapcc/PyKMIP/security/code-scanning/4)

To fix the issue, we should avoid logging the `secret_id` directly. Instead, we can log a generic success message without including sensitive details. If additional context is needed for debugging, we can use a unique transaction ID or similar mechanism that does not expose sensitive information. This ensures that sensitive data is not logged while still providing useful information for debugging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
