### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/kmip/demos/pie/derive_key.py
+++ b/kmip/demos/pie/derive_key.py
@@ -123,7 +123,7 @@ if __name__ == '__main__':
                 cryptographic_algorithm=enums.CryptographicAlgorithm.RC4
             )
             logger.info("Successfully derived a new secret via HMAC.")
-            logger.info("Secret ID: {0}".format(secret_id))
+            logger.debug("Derived secret ID (truncated): {0}".format(secret_id[:8] + "..." if secret_id else "N/A"))
         except Exception as e:
             logger.error(e)
 
@@ -141,7 +141,7 @@ if __name__ == '__main__':
                 cryptographic_length=128
             )
             logger.info("Successfully derived a new secret via hashing.")
-            logger.info("Secret ID: {0}".format(secret_id))
+            logger.debug("Derived secret ID (truncated): {0}".format(secret_id[:8] + "..." if secret_id else "N/A"))
         except Exception as e:
             logger.error(e)
 
@@ -172,6 +172,6 @@ if __name__ == '__main__':
             logger.info(
                 "Successfully derived a new secret via NIST 800 108-C."
             )
-            logger.info("Secret ID: {0}".format(secret_id))
+            logger.debug("Derived secret ID (truncated): {0}".format(secret_id[:8] + "..." if secret_id else "N/A"))
         except Exception as e:
             logger.error(e)


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/9](https://github.com/sapcc/PyKMIP/security/code-scanning/9)

To fix the issue, we should avoid logging the `secret_id` in clear text. Instead, we can log a generic success message without including the sensitive `secret_id`. If logging the `secret_id` is necessary for debugging or auditing purposes, it should be masked or obfuscated to prevent exposure of the full value. For example, we can log only the first few characters of the `secret_id` or use a hash of it.

The changes will involve:
1. Replacing the logging statements that include `secret_id` with safer alternatives.
2. Ensuring that the fix is applied consistently across all instances where `secret_id` is logged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
