### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/kmip/demos/pie/derive_key.py
+++ b/kmip/demos/pie/derive_key.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
                 cryptographic_algorithm=enums.CryptographicAlgorithm.AES
             )
             logger.info("Successfully derived a new secret via PBKDF2.")
-            logger.info("Secret ID: {0}".format(secret_id))
+            logger.info("A new secret has been derived successfully.")
         except Exception as e:
             logger.error(e)
 
@@ -96,7 +96,7 @@ if __name__ == '__main__':
                 cryptographic_length=256
             )
             logger.info("Successfully derived a new secret via encryption.")
-            logger.info("Secret ID: {0}".format(secret_id))
+            logger.info("A new secret has been derived successfully.")
         except Exception as e:
             logger.error(e)
 


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/5](https://github.com/sapcc/PyKMIP/security/code-scanning/5)

To fix the issue, we should avoid logging sensitive information like `secret_id` in clear text. Instead, we can log a generic success message without including the sensitive data. If necessary, we can log a hashed or masked version of the `secret_id` to provide traceability without exposing the actual value. This ensures that sensitive data is not exposed while maintaining some level of logging for debugging or auditing purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
