### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/kmip/demos/pie/derive_key.py
+++ b/kmip/demos/pie/derive_key.py
@@ -123,7 +123,7 @@ if __name__ == '__main__':
                 cryptographic_algorithm=enums.CryptographicAlgorithm.RC4
             )
             logger.info("Successfully derived a new secret via HMAC.")
-            logger.info("Secret ID: {0}".format(secret_id))
+            logger.info("A new secret has been derived successfully, but its ID will not be logged for security reasons.")
         except Exception as e:
             logger.error(e)
 


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/5](https://github.com/sapcc/PyKMIP/security/code-scanning/5)

To fix the issue, we should avoid logging the `secret_id` directly. Instead, we can log a generic success message without including the sensitive data. This ensures that no sensitive information is exposed in the logs while still providing useful feedback about the operation's success. 

The changes will involve:
1. Removing the log statement that includes `secret_id` on line 126.
2. Replacing it with a generic success message that does not reveal sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
