### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/kmip/demos/pie/derive_key.py
+++ b/kmip/demos/pie/derive_key.py
@@ -172,6 +172,6 @@ if __name__ == '__main__':
             logger.info(
                 "Successfully derived a new secret via NIST 800 108-C."
             )
-            logger.info("Secret ID: {0}".format(secret_id))
+            logger.info("A new secret has been derived successfully, but its ID will not be logged for security reasons.")
         except Exception as e:
             logger.error(e)


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/9](https://github.com/sapcc/PyKMIP/security/code-scanning/9)

To fix the issue, we should avoid logging the `secret_id` directly. Instead, we can log a generic success message that does not include sensitive information. This ensures that the functionality remains intact while adhering to security best practices. Specifically, we will replace the line that logs the `secret_id` with a message indicating that a secret was successfully derived, without revealing the ID.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
