### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/kmip/demos/pie/derive_key.py
+++ b/kmip/demos/pie/derive_key.py
@@ -141,7 +141,7 @@ if __name__ == '__main__':
                 cryptographic_length=128
             )
             logger.info("Successfully derived a new secret via hashing.")
-            logger.info("Secret ID: {0}".format(secret_id))
+            logger.info("A new secret has been derived successfully, but its ID will not be logged for security reasons.")
         except Exception as e:
             logger.error(e)
 


### PR DESCRIPTION
Potential fix for [https://github.com/sapcc/PyKMIP/security/code-scanning/5](https://github.com/sapcc/PyKMIP/security/code-scanning/5)

To fix the problem, we should avoid logging the secret ID in clear text. Instead, we can log a generic success message, similar to how other secret derivation operations are handled in this file (see lines 126 and 175). Specifically, in kmip/demos/pie/derive_key.py, replace the line that logs `"Secret ID: {0}".format(secret_id)` with a message indicating that a new secret has been derived, but its ID will not be logged for security reasons. No new imports or methods are required; just update the log statement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
