### PR TITLE
[kmip] switch OpenStack auth from application credentials to service user

### DIFF
--- a/kmip/services/server/barbican.py
+++ b/kmip/services/server/barbican.py
@@ -78,9 +78,10 @@ class OpenstackHelper:
         auth = dict(
             auth_url='https://identity-3.{}.cloud.sap/v3'.format(self.region),
             username=os.environ.get("OS_USERNAME"),
+            password=os.environ.get("OS_PASSWORD"),
             user_domain_name=self.user_domain_name,
-            application_credential_name=os.environ.get('OS_APPLICATION_CREDENTIAL_NAME'),
-            application_credential_secret=os.environ.get('OS_APPLICATION_CREDENTIAL_SECRET'),
+            project_name=self.project_name,
+            project_domain_name=self.project_domain_name,
         )
         kwargs = {}
         if os.environ.get('OS_CERT'):


### PR DESCRIPTION
## Summary

- Replace application credential auth with username/password using the `kmip` service user in the `Default` domain
- Add `project_name` and `project_domain_name` to the auth dict (required for password-based auth scoping)
- Remove `application_credential_name` and `application_credential_secret` from the auth dict

## Related PRs
- helm-charts: https://github.com/sapcc/helm-charts/pull/11766
- secrets: https://github.wdf.sap.corp/cc/secrets/pull/20561