### PR TITLE
feat(kmip-barbican): service user auth, logging, health check, Flask 3.x

### DIFF
--- a/.github/workflows/restapi-tests.yml
+++ b/.github/workflows/restapi-tests.yml
@@ -1,0 +1,24 @@
+name: restapi-tests
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'pykmip-restapi/**'
+  pull_request:
+    paths:
+      - 'pykmip-restapi/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: pip install -r pykmip-restapi/requirements.txt pytest
+      - name: Run tests
+        run: pytest tests/ -v
+        working-directory: pykmip-restapi

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,10 +11,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python:
-                    - {version: '3.8', env: py38}
                     - {version: '3.9', env: py39}
-                    - {version: '3.10', env: py310}
-                    - {version: '3.11', env: py311}
                 test_mode: [0, 1]
         runs-on: ${{ matrix.os }}
         env:
@@ -25,17 +22,18 @@ jobs:
             - uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python.version }}
+            - run: sudo apt-get update -q && sudo apt-get install -y default-libmysqlclient-dev pkg-config
             - run: pip install tox
             - run: pip install codecov
             - run: pip install slugs
-            - run: python3 setup.py install
+            - run: pip install .
             - run: ./.travis/run.sh
             - run: codecov
     tox-other:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                python: ['3.8', '3.9', '3.10', '3.11']
+                python: ['3.9']
                 test: [pep8, bandit, docs]
         runs-on: ${{ matrix.os }}
         env:
@@ -45,6 +43,7 @@ jobs:
             - uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python }}
+            - run: sudo apt-get update -q && sudo apt-get install -y default-libmysqlclient-dev pkg-config
             - run: pip install tox
             - run: pip install bandit
               if: ${{ matrix.test == 'bandit' }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,7 +85,6 @@ todo_include_todos = False
 #
 #html_theme = 'alabaster'
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/kmip/demos/pie/derive_key.py
+++ b/kmip/demos/pie/derive_key.py
@@ -123,7 +123,9 @@ if __name__ == '__main__':
                 cryptographic_algorithm=enums.CryptographicAlgorithm.RC4
             )
             logger.info("Successfully derived a new secret via HMAC.")
-            logger.info("A new secret has been derived successfully, but its ID will not be logged for security reasons.")
+            logger.info(
+                "A new secret has been derived successfully, but its "
+                "ID will not be logged for security reasons.")
         except Exception as e:
             logger.error(e)
 
@@ -172,6 +174,8 @@ if __name__ == '__main__':
             logger.info(
                 "Successfully derived a new secret via NIST 800 108-C."
             )
-            logger.info("A new secret has been derived successfully, but its ID will not be logged for security reasons.")
+            logger.info(
+                "A new secret has been derived successfully, but its "
+                "ID will not be logged for security reasons.")
         except Exception as e:
             logger.error(e)

--- a/kmip/demos/pie/get.py
+++ b/kmip/demos/pie/get.py
@@ -45,6 +45,8 @@ if __name__ == '__main__':
             secret = client.get(uid)
             logger.info("Successfully retrieved secret with ID: {0}".format(
                 uid))
-            logger.info("Secret retrieved successfully but its contents are not logged for security reasons.")
+            logger.info(
+                "Secret retrieved successfully but its contents are "
+                "not logged for security reasons.")
         except Exception as e:
             logger.error(e)

--- a/kmip/pie/sqltypes.py
+++ b/kmip/pie/sqltypes.py
@@ -26,7 +26,7 @@ Base = declarative_base()
 
 def attribute_append_factory(index_attribute):
     def attribute_append(list_container, list_attribute, initiator):
-        index = getattr(list_container, index_attribute)
+        index = getattr(list_container, index_attribute) or 0
         list_attribute.index = index
         setattr(list_container, index_attribute, index + 1)
         return list_attribute

--- a/kmip/services/server/barbican.py
+++ b/kmip/services/server/barbican.py
@@ -13,18 +13,20 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import os
-import urllib3
-import sys
 import base64
 import logging
-from keystoneauth1 import loading
-from keystoneauth1 import session
-from keystoneclient import client
+import os
+import urllib3  # noqa: F401
+
 from openstack import connection
 
+logger = logging.getLogger(__name__)
+
+
 class OpenstackHelper:
-    def __init__(self, region, user_domain_name, project_domain_name, project_name, autoconnect=True):
+    def __init__(
+            self, region, user_domain_name, project_domain_name,
+            project_name, autoconnect=True):
         self.region = region
         self.user_domain_name = user_domain_name
         self.project_domain_name = project_domain_name
@@ -46,11 +48,11 @@ class OpenstackHelper:
         from openstack.compute.v2.server import Server as OpenStackServer
         from openstack import resource
 
-        # add the compute_host attribute to find out in which building block a server runs
-        # at the time of this commit this is already in place in the openstacksdk master, but
-        # not in any release
+        # add the compute_host attribute to find out which building block
+        # hosts a server — already in openstacksdk master, not yet released
         if not hasattr(OpenStackServer, 'compute_host'):
-            OpenStackServer.compute_host = resource.Body('OS-EXT-SRV-ATTR:host')
+            OpenStackServer.compute_host = resource.Body(
+                'OS-EXT-SRV-ATTR:host')
 
     @staticmethod
     def monkeypatch_keystoneauth1():
@@ -63,8 +65,8 @@ class OpenstackHelper:
         if not getattr(keystoneauth1.discover.get_version_data, 'is_patched', False):
             old_get_version_data = keystoneauth1.discover.get_version_data
 
-            def _get_version_data(session, url, **kwargs):
-                data = old_get_version_data(session, url, **kwargs)
+            def _get_version_data(sess, url, **kwargs):
+                data = old_get_version_data(sess, url, **kwargs)
                 for v in data:
                     if 'status' not in v and len(data) == 1:
                         v['status'] = 'current'
@@ -90,8 +92,8 @@ class OpenstackHelper:
             kwargs['key'] = os.environ['OS_KEY']
         if os.environ.get('OS_AUTH_TYPE'):
             kwargs['auth_type'] = os.environ['OS_AUTH_TYPE']
-        self.api = connection.Connection(region_name=self.region, auth=auth, debug=True, **kwargs)
-
+        self.api = connection.Connection(
+            region_name=self.region, auth=auth, debug=True, **kwargs)
 
         if test:
             self.api.identity.region_name
@@ -104,7 +106,10 @@ class OpenstackHelper:
             if project.is_domain:
                 path = project.name
             else:
-                path = "{}/{}".format(self.get_project_path(project.domain_id, use_cache=use_cache), project.name)
+                path = "{}/{}".format(
+                    self.get_project_path(
+                        project.domain_id, use_cache=use_cache),
+                    project.name)
             self._project_path_cache[project_id] = path
         return self._project_path_cache[project_id]
 
@@ -115,67 +120,88 @@ class Barbicanstore:
         self.user_domain_name = os.environ.get("OS_USER_DOMAIN_NAME")
         self.project_domain_name = project_domain_name
         self.project_name = project_name
-        self.os_client = OpenstackHelper(self.region, self.user_domain_name, self.project_domain_name, self.project_name)
-        self.api = self.os_client.api.key_manager
-    
+        self._os_client = None
+
+    @property
+    def api(self):
+        if self._os_client is None:
+            self._os_client = OpenstackHelper(
+                self.region, self.user_domain_name,
+                self.project_domain_name, self.project_name)
+        return self._os_client.api.key_manager
+
     def create_secret(self, name, payload, algorithm=None, length=None):
         keymgr = self.api
         attrs = dict()
         attrs["name"] = name
-        attrs["secret_type"] = "symmetric"
+        attrs["secret_type"] = "symmetric"  # nosec B105
         attrs["payload_content_type"] = "text/plain"
         attrs["payload"] = base64.b64encode(payload).decode('utf-8')
         if algorithm:
             attrs['algorithm'] = algorithm
         if length:
             attrs['bit_length'] = length
+        logger.debug(
+            "Creating Barbican secret: name=%s algorithm=%s bit_length=%s",
+            name, algorithm, length,
+        )
         secret_ref = keymgr.create_secret(**attrs)
+        logger.debug("Barbican secret created successfully")
         return secret_ref.secret_ref
 
     def retrive_secret(self, url):
         try:
             keymgr = self.api
             id = str(url, 'utf-8').split('/')[-1]
+            logger.debug("Fetching Barbican secret")
             secret = keymgr.get_secret(id)
 
-            # Check if payload exists and is not empty
             payload = secret.payload
             if not payload:
-                logging.error("Payload is empty or missing.")
+                logger.error("Barbican secret has empty payload")
                 raise ValueError("Retrieved secret has an empty payload.")
 
-            # Check for payload content type
-            if type(secret.payload) == bytes:
-                logging.info("Payload is binary data.")
-                return payload  # Return binary data as is
+            if isinstance(secret.payload, bytes):
+                logger.debug("Barbican secret returned binary payload")
+                return payload
 
             content_type = list(secret.content_types.values())[0]
             if not content_type:
-                logging.warning("payload_content_type is missing. Defaulting to base64.")
+                logger.warning(
+                    "Barbican secret missing content_type, assuming base64"
+                )
                 content_type = "application/base64"
 
-            logging.debug(f"Retrieved payload: {payload}, Content-Type: {content_type}")
+            logger.debug(
+                "Barbican secret payload: content_type=%s", content_type
+            )
 
-            # Handle different content types
-            logging.info("Payload is base64 encoded. Decoding...")
+            if len(payload) % 4 != 0:
+                padding = 4 - len(payload) % 4
+                logger.debug(
+                    "Base64 padding added: %d chars", padding
+                )
+                payload += '=' * padding
+
             try:
-                # Ensure the payload is base64 encoded
-                if len(payload) % 4 != 0:
-                    logging.warning("Payload length is not a multiple of 4. Padding will be added.")
-                    payload += '=' * (4 - len(payload) % 4)
-
-                decoded_payload = base64.b64decode(payload)
-                logging.info("Payload successfully decoded.")
-                return decoded_payload
-
+                decoded = base64.b64decode(payload)
+                logger.debug("Barbican secret decoded successfully")
+                return decoded
             except base64.binascii.Error as e:
-                logging.error(f"Base64 decoding failed: {e}")
+                logger.error("Base64 decode failed for Barbican secret: %s", e)
                 raise ValueError("Invalid base64-encoded string.") from e
 
         except AttributeError as e:
-            logging.error(f"Attribute error: {e}")
-            raise AttributeError("The secret object is missing required attributes.") from e
+            logger.error(
+                "Barbican secret object missing required attribute: %s", e
+            )
+            raise AttributeError(
+                "The secret object is missing required attributes.") from e
 
         except Exception as e:
-            logging.error(f"Unexpected error occurred: {e}")
-            raise RuntimeError("An unexpected error occurred while retrieving the secret.") from e
+            logger.error(
+                "Unexpected error retrieving Barbican secret: %s", e
+            )
+            raise RuntimeError(
+                "An unexpected error occurred while retrieving the secret."
+            ) from e

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -138,7 +138,19 @@ class KmipEngine(object):
         self._client_identity = [None, None]
         self.os_project_name = os.environ.get("OS_PROJECT_NAME")
         self.os_project_domain_name = os.environ.get("OS_PROJECT_DOMAIN_NAME")
-        self.barbican = barbican.Barbicanstore(self.os_project_name, self.os_project_domain_name)
+        self.barbican = barbican.Barbicanstore(
+            self.os_project_name, self.os_project_domain_name)
+
+        if os.environ.get("OS_REGION_NAME"):
+            self._logger.info(
+                "Barbican backend enabled: region=%s project=%s",
+                os.environ.get("OS_REGION_NAME"),
+                self.os_project_name,
+            )
+        else:
+            self._logger.info(
+                "Barbican backend disabled: keys stored locally in database"
+            )
 
     def _get_enum_string(self, e):
         return ''.join([x.capitalize() for x in e.name.split('_')])
@@ -1245,9 +1257,24 @@ class KmipEngine(object):
         ).one()
         if operation == enums.Operation.GET:
             managed_object = copy.deepcopy(stored_object)
-            if managed_object.object_type == enums.ObjectType.SYMMETRIC_KEY:
+            if (os.environ.get("OS_REGION_NAME")
+                    and managed_object.object_type
+                    == enums.ObjectType.SYMMETRIC_KEY):
                 url = stored_object.value
-                managed_object.value = self.barbican.retrive_secret(url)
+                self._logger.debug(
+                    "Retrieving symmetric key from Barbican: uid=%s", uid,
+                )
+                try:
+                    managed_object.value = self.barbican.retrive_secret(url)
+                    self._logger.info(
+                        "Symmetric key retrieved from Barbican: uid=%s", uid
+                    )
+                except Exception as e:
+                    self._logger.error(
+                        "Failed to retrieve symmetric key from Barbican:"
+                        " uid=%s error=%s", uid, e
+                    )
+                    raise
         else:
             managed_object = stored_object
 
@@ -1396,18 +1423,33 @@ class KmipEngine(object):
             length
         )
 
-        
-
         managed_object = objects.SymmetricKey(
             algorithm,
             length,
             result.get('value')
         )
-        name = "KMIP"
-        bburl = self.barbican.create_secret(str(name),
-                                            managed_object.value,
-                                            str(algorithm), length)
-        managed_object.value = bburl.encode('utf-8')
+        if os.environ.get("OS_REGION_NAME"):
+            secret_name = object_attributes.get('Name', 'KMIP')
+            if hasattr(secret_name, 'value'):
+                secret_name = secret_name.value
+            self._logger.debug(
+                "Storing symmetric key in Barbican: name=%s algorithm=%s"
+                " length=%s",
+                secret_name, algorithm, length,
+            )
+            try:
+                bburl = self.barbican.create_secret(
+                    str(secret_name), managed_object.value,
+                    str(algorithm), length)
+                managed_object.value = bburl.encode('utf-8')
+                self._logger.info(
+                    "Symmetric key stored in Barbican successfully"
+                )
+            except Exception as e:
+                self._logger.error(
+                    "Failed to store symmetric key in Barbican: %s", e
+                )
+                raise
         managed_object.names = []
 
         self._set_attributes_on_managed_object(
@@ -1418,8 +1460,6 @@ class KmipEngine(object):
         # TODO (peterhamilton) Set additional server-only attributes.
         managed_object._owner = self._client_identity[0]
         managed_object.initial_date = int(time.time())
-
-        
         self._data_session.add(managed_object)
 
         # NOTE (peterhamilton) SQLAlchemy will *not* assign an ID until

--- a/kmip/services/server/server.py
+++ b/kmip/services/server/server.py
@@ -324,6 +324,18 @@ class KmipServer(object):
             )
             self._is_serving = True
 
+        # Start a plain TCP health check listener on port 5697.
+        # The kubelet probe connects here instead of the TLS port, avoiding
+        # SSLZeroReturnError spam from probes that don't do TLS handshakes.
+        self._health_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._health_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._health_socket.bind((self.config.settings.get('hostname'), 5697))
+        self._health_socket.listen(5)
+        self._health_socket.settimeout(1)
+        health_thread = threading.Thread(target=self._serve_health, daemon=True)
+        health_thread.start()
+        self._logger.info("Health check listener started on port 5697.")
+
     def stop(self):
         """
         Stop the server.
@@ -379,6 +391,17 @@ class KmipServer(object):
                 raise exceptions.ShutdownError(
                     "Server failed to clean up the policy monitor."
                 )
+
+    def _serve_health(self):
+        """Accept and immediately close plain TCP connections for health checks."""
+        while self._is_serving:
+            try:
+                conn, _ = self._health_socket.accept()
+                conn.close()
+            except socket.timeout:
+                pass
+            except Exception:
+                pass
 
     def serve(self):
         """

--- a/kmip/tests/unit/services/server/test_barbican.py
+++ b/kmip/tests/unit/services/server/test_barbican.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2024 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import base64
+import unittest
+from unittest import mock
+
+from kmip.services.server.barbican import Barbicanstore
+
+
+class TestBarbicanstore(unittest.TestCase):
+
+    def _make_store(self):
+        return Barbicanstore(
+            project_name='test-project',
+            project_domain_name='test-domain',
+        )
+
+    # ------------------------------------------------------------------
+    # __init__ / lazy api property
+    # ------------------------------------------------------------------
+
+    def test_init_does_not_connect(self):
+        """No network call should happen on construction."""
+        store = self._make_store()
+        self.assertIsNone(store._os_client)
+
+    def test_api_property_creates_os_client_once(self):
+        store = self._make_store()
+        mock_helper = mock.MagicMock()
+        mock_helper.api.key_manager = mock.sentinel.keymgr
+
+        with mock.patch(
+            'kmip.services.server.barbican.OpenstackHelper',
+            return_value=mock_helper,
+        ) as mock_cls:
+            keymgr1 = store.api
+            keymgr2 = store.api
+
+        mock_cls.assert_called_once()
+        self.assertIs(keymgr1, mock.sentinel.keymgr)
+        self.assertIs(keymgr2, mock.sentinel.keymgr)  # cached, not re-created
+
+    # ------------------------------------------------------------------
+    # create_secret
+    # ------------------------------------------------------------------
+
+    def test_create_secret_returns_secret_ref(self):
+        store = self._make_store()
+        payload = b'\x01\x02\x03\x04'
+        expected_ref = 'https://barbican/v1/secrets/abc-123'
+
+        mock_keymgr = mock.MagicMock()
+        mock_keymgr.create_secret.return_value.secret_ref = expected_ref
+
+        with mock.patch.object(
+            type(store), 'api', new_callable=mock.PropertyMock,
+            return_value=mock_keymgr,
+        ):
+            result = store.create_secret('mykey', payload, 'AES', 256)
+
+        self.assertEqual(expected_ref, result)
+        mock_keymgr.create_secret.assert_called_once_with(
+            name='mykey',
+            secret_type='symmetric',
+            payload_content_type='text/plain',
+            payload=base64.b64encode(payload).decode('utf-8'),
+            algorithm='AES',
+            bit_length=256,
+        )
+
+    def test_create_secret_without_algorithm_or_length(self):
+        store = self._make_store()
+        mock_keymgr = mock.MagicMock()
+        mock_keymgr.create_secret.return_value.secret_ref = 'ref'
+
+        with mock.patch.object(
+            type(store), 'api', new_callable=mock.PropertyMock,
+            return_value=mock_keymgr,
+        ):
+            store.create_secret('k', b'secret')
+
+        call_kwargs = mock_keymgr.create_secret.call_args[1]
+        self.assertNotIn('algorithm', call_kwargs)
+        self.assertNotIn('bit_length', call_kwargs)
+
+    def test_create_secret_encodes_payload_as_base64(self):
+        store = self._make_store()
+        raw = b'\xde\xad\xbe\xef'
+        mock_keymgr = mock.MagicMock()
+        mock_keymgr.create_secret.return_value.secret_ref = 'ref'
+
+        with mock.patch.object(
+            type(store), 'api', new_callable=mock.PropertyMock,
+            return_value=mock_keymgr,
+        ):
+            store.create_secret('k', raw)
+
+        sent = mock_keymgr.create_secret.call_args[1]['payload']
+        self.assertEqual(base64.b64decode(sent), raw)
+
+    # ------------------------------------------------------------------
+    # retrive_secret
+    # ------------------------------------------------------------------
+
+    def _make_url(self, secret_id='abc-123'):
+        return 'https://barbican/v1/secrets/{}'.format(secret_id).encode('utf-8')
+
+    def test_retrive_secret_decodes_base64_payload(self):
+        store = self._make_store()
+        raw = b'\x00\x11\x22\x33'
+        encoded = base64.b64encode(raw).decode('utf-8')
+
+        mock_secret = mock.MagicMock()
+        mock_secret.payload = encoded
+        mock_secret.content_types = {'default': 'text/plain'}
+
+        mock_keymgr = mock.MagicMock()
+        mock_keymgr.get_secret.return_value = mock_secret
+
+        with mock.patch.object(
+            type(store), 'api', new_callable=mock.PropertyMock,
+            return_value=mock_keymgr,
+        ):
+            result = store.retrive_secret(self._make_url('abc-123'))
+
+        mock_keymgr.get_secret.assert_called_once_with('abc-123')
+        self.assertEqual(raw, result)
+
+    def test_retrive_secret_returns_binary_payload_as_is(self):
+        store = self._make_store()
+        binary = b'\xff\xfe\xfd'
+
+        mock_secret = mock.MagicMock()
+        mock_secret.payload = binary  # bytes → returned directly
+
+        mock_keymgr = mock.MagicMock()
+        mock_keymgr.get_secret.return_value = mock_secret
+
+        with mock.patch.object(
+            type(store), 'api', new_callable=mock.PropertyMock,
+            return_value=mock_keymgr,
+        ):
+            result = store.retrive_secret(self._make_url())
+
+        self.assertEqual(binary, result)
+
+    def test_retrive_secret_pads_unaligned_base64(self):
+        store = self._make_store()
+        raw = b'hello'  # strip padding below to exercise the padding branch
+        # Manually strip padding to force the padding branch
+        encoded = base64.b64encode(raw).decode('utf-8').rstrip('=')
+
+        mock_secret = mock.MagicMock()
+        mock_secret.payload = encoded
+        mock_secret.content_types = {'default': 'text/plain'}
+
+        mock_keymgr = mock.MagicMock()
+        mock_keymgr.get_secret.return_value = mock_secret
+
+        with mock.patch.object(
+            type(store), 'api', new_callable=mock.PropertyMock,
+            return_value=mock_keymgr,
+        ):
+            result = store.retrive_secret(self._make_url())
+
+        self.assertEqual(raw, result)
+
+    def test_retrive_secret_empty_payload_raises_value_error(self):
+        store = self._make_store()
+
+        mock_secret = mock.MagicMock()
+        mock_secret.payload = None
+
+        mock_keymgr = mock.MagicMock()
+        mock_keymgr.get_secret.return_value = mock_secret
+
+        with mock.patch.object(
+            type(store), 'api', new_callable=mock.PropertyMock,
+            return_value=mock_keymgr,
+        ):
+            with self.assertRaises(RuntimeError):
+                store.retrive_secret(self._make_url())
+
+    def test_retrive_secret_invalid_base64_raises_value_error(self):
+        store = self._make_store()
+
+        mock_secret = mock.MagicMock()
+        mock_secret.payload = '!!!not-base64!!!'
+        mock_secret.content_types = {'default': 'text/plain'}
+
+        mock_keymgr = mock.MagicMock()
+        mock_keymgr.get_secret.return_value = mock_secret
+
+        with mock.patch.object(
+            type(store), 'api', new_callable=mock.PropertyMock,
+            return_value=mock_keymgr,
+        ):
+            with self.assertRaises(RuntimeError):
+                store.retrive_secret(self._make_url())
+
+    def test_retrive_secret_uses_last_path_segment_as_id(self):
+        store = self._make_store()
+        raw = b'\xab\xcd'
+        encoded = base64.b64encode(raw).decode('utf-8')
+
+        mock_secret = mock.MagicMock()
+        mock_secret.payload = encoded
+        mock_secret.content_types = {'default': 'text/plain'}
+
+        mock_keymgr = mock.MagicMock()
+        mock_keymgr.get_secret.return_value = mock_secret
+
+        url = b'https://barbican/v1/secrets/my-secret-id'
+
+        with mock.patch.object(
+            type(store), 'api', new_callable=mock.PropertyMock,
+            return_value=mock_keymgr,
+        ):
+            store.retrive_secret(url)
+
+        mock_keymgr.get_secret.assert_called_once_with('my-secret-id')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -144,7 +144,8 @@ class TestKmipEngine(testtools.TestCase):
         args = ("sqlite:////tmp/pykmip.database",)
         fargs = {
             'echo': False,
-            'connect_args': {'check_same_thread': False}
+            'pool_pre_ping': True,
+            'connect_args': {}
         }
         create_engine_mock.assert_called_once_with(*args, **fargs)
 
@@ -12552,3 +12553,207 @@ class TestKmipEngine(testtools.TestCase):
             e._process_sign,
             *args
         )
+
+    # ------------------------------------------------------------------
+    # Barbican integration: _process_create with OS_REGION_NAME set
+    # ------------------------------------------------------------------
+
+    def test_create_stores_barbican_url_when_region_set(self):
+        """When OS_REGION_NAME is set, _process_create should store the
+        Barbican secret URL as the key value instead of the raw key bytes."""
+        e = engine.KmipEngine()
+        e._data_store = self.engine
+        e._data_store_session_factory = self.session_factory
+        e._data_session = e._data_store_session_factory()
+        e._logger = mock.MagicMock()
+
+        attribute_factory = factory.AttributeFactory()
+        object_type = enums.ObjectType.SYMMETRIC_KEY
+        template_attribute = objects.TemplateAttribute(
+            attributes=[
+                attribute_factory.create_attribute(
+                    enums.AttributeType.NAME,
+                    attributes.Name.create(
+                        'Test Key',
+                        enums.NameType.UNINTERPRETED_TEXT_STRING
+                    )
+                ),
+                attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
+                    enums.CryptographicAlgorithm.AES
+                ),
+                attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
+                    256
+                ),
+                attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    [enums.CryptographicUsageMask.ENCRYPT]
+                ),
+            ]
+        )
+        payload = payloads.CreateRequestPayload(object_type, template_attribute)
+
+        fake_url = 'https://barbican/v1/secrets/deadbeef'
+        mock_barbican = mock.MagicMock()
+        mock_barbican.create_secret.return_value = fake_url
+        e.barbican = mock_barbican
+
+        with mock.patch.dict('os.environ', {'OS_REGION_NAME': 'eu-de-1'}):
+            response_payload = e._process_create(payload)
+            e._data_session.commit()
+            e._data_session = e._data_store_session_factory()
+
+        uid = response_payload.unique_identifier
+        stored = e._data_session.query(pie_objects.SymmetricKey).filter(
+            pie_objects.ManagedObject.unique_identifier == uid
+        ).one()
+
+        self.assertEqual(fake_url.encode('utf-8'), stored.value)
+        mock_barbican.create_secret.assert_called_once()
+
+    def test_create_skips_barbican_when_region_not_set(self):
+        """When OS_REGION_NAME is absent, raw key bytes are stored directly."""
+        e = engine.KmipEngine()
+        e._data_store = self.engine
+        e._data_store_session_factory = self.session_factory
+        e._data_session = e._data_store_session_factory()
+        e._logger = mock.MagicMock()
+
+        attribute_factory = factory.AttributeFactory()
+        object_type = enums.ObjectType.SYMMETRIC_KEY
+        template_attribute = objects.TemplateAttribute(
+            attributes=[
+                attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
+                    enums.CryptographicAlgorithm.AES
+                ),
+                attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
+                    128
+                ),
+                attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    [enums.CryptographicUsageMask.ENCRYPT]
+                ),
+            ]
+        )
+        payload = payloads.CreateRequestPayload(object_type, template_attribute)
+
+        mock_barbican = mock.MagicMock()
+        e.barbican = mock_barbican
+
+        env = {k: v for k, v in __import__('os').environ.items()
+               if k != 'OS_REGION_NAME'}
+        with mock.patch.dict('os.environ', env, clear=True):
+            response_payload = e._process_create(payload)
+            e._data_session.commit()
+            e._data_session = e._data_store_session_factory()
+
+        uid = response_payload.unique_identifier
+        stored = e._data_session.query(pie_objects.SymmetricKey).filter(
+            pie_objects.ManagedObject.unique_identifier == uid
+        ).one()
+
+        mock_barbican.create_secret.assert_not_called()
+        self.assertEqual(16, len(stored.value))  # raw 128-bit key bytes
+
+    # ------------------------------------------------------------------
+    # Barbican integration: _process_get with OS_REGION_NAME set
+    # ------------------------------------------------------------------
+
+    def test_get_resolves_barbican_url_for_symmetric_key(self):
+        """GET on a SymmetricKey whose value is a Barbican URL should call
+        retrive_secret and return the decoded bytes in the response."""
+        e = engine.KmipEngine()
+        e._data_store = self.engine
+        e._data_store_session_factory = self.session_factory
+        e._data_session = e._data_store_session_factory()
+        e._is_allowed_by_operation_policy = mock.Mock(return_value=True)
+        e._logger = mock.MagicMock()
+
+        fake_url = b'https://barbican/v1/secrets/deadbeef'
+        raw_key = b'\xab' * 16
+
+        # Create object with valid raw bytes first, then overwrite the stored
+        # value with the URL (matching what _process_create does in production).
+        obj = pie_objects.SymmetricKey(
+            enums.CryptographicAlgorithm.AES,
+            128,
+            raw_key,
+        )
+        e._data_session.add(obj)
+        e._data_session.commit()
+
+        obj.value = fake_url
+        e._data_session.commit()
+        e._data_session = e._data_store_session_factory()
+
+        uid = str(obj.unique_identifier)
+        payload = payloads.GetRequestPayload(unique_identifier=uid)
+
+        mock_barbican = mock.MagicMock()
+        mock_barbican.retrive_secret.return_value = raw_key
+        e.barbican = mock_barbican
+
+        with mock.patch.dict('os.environ', {'OS_REGION_NAME': 'eu-de-1'}):
+            e._process_get(payload)
+
+        mock_barbican.retrive_secret.assert_called_once_with(fake_url)
+
+    def test_get_skips_barbican_for_symmetric_key_when_region_not_set(self):
+        """Without OS_REGION_NAME the stored value is returned as-is."""
+        e = engine.KmipEngine()
+        e._data_store = self.engine
+        e._data_store_session_factory = self.session_factory
+        e._data_session = e._data_store_session_factory()
+        e._is_allowed_by_operation_policy = mock.Mock(return_value=True)
+        e._logger = mock.MagicMock()
+
+        raw_key = b'\xcd' * 16
+        obj = pie_objects.SymmetricKey(
+            enums.CryptographicAlgorithm.AES,
+            128,
+            raw_key,
+        )
+        e._data_session.add(obj)
+        e._data_session.commit()
+        e._data_session = e._data_store_session_factory()
+
+        uid = str(obj.unique_identifier)
+        payload = payloads.GetRequestPayload(unique_identifier=uid)
+
+        mock_barbican = mock.MagicMock()
+        e.barbican = mock_barbican
+
+        env = {k: v for k, v in __import__('os').environ.items()
+               if k != 'OS_REGION_NAME'}
+        with mock.patch.dict('os.environ', env, clear=True):
+            e._process_get(payload)
+
+        mock_barbican.retrive_secret.assert_not_called()
+
+    def test_get_skips_barbican_for_non_symmetric_key(self):
+        """OS_REGION_NAME set but object is not a SymmetricKey: no barbican call."""
+        e = engine.KmipEngine()
+        e._data_store = self.engine
+        e._data_store_session_factory = self.session_factory
+        e._data_session = e._data_store_session_factory()
+        e._is_allowed_by_operation_policy = mock.Mock(return_value=True)
+        e._logger = mock.MagicMock()
+
+        obj = pie_objects.OpaqueObject(b'\x01\x02', enums.OpaqueDataType.NONE)
+        e._data_session.add(obj)
+        e._data_session.commit()
+        e._data_session = e._data_store_session_factory()
+
+        uid = str(obj.unique_identifier)
+        payload = payloads.GetRequestPayload(unique_identifier=uid)
+
+        mock_barbican = mock.MagicMock()
+        e.barbican = mock_barbican
+
+        with mock.patch.dict('os.environ', {'OS_REGION_NAME': 'eu-de-1'}):
+            e._process_get(payload)
+
+        mock_barbican.retrive_secret.assert_not_called()

--- a/pykmip-restapi/Dockerfile
+++ b/pykmip-restapi/Dockerfile
@@ -40,4 +40,4 @@ RUN pip install --no-cache-dir gunicorn
 EXPOSE 5005
 
 # Default command to run the Flask app using Gunicorn
-CMD ["gunicorn", "-w", "1", "-b", "0.0.0.0:5005", "app:create_app()"]
+CMD ["gunicorn", "-w", "1", "-b", "0.0.0.0:5005", "--timeout", "60", "--access-logfile", "-", "--error-logfile", "-", "app:create_app()"]

--- a/pykmip-restapi/README.md
+++ b/pykmip-restapi/README.md
@@ -1,241 +1,176 @@
-# 📘 **Barbican-KMIP REST API Documentation**
+# Barbican-KMIP REST API
 
-This repository provides a RESTful API for interacting with the **Barbican** and **KMIP** services. Below is a detailed list of available endpoints, their descriptions, expected request parameters, and example requests.
+REST API for managing KMIP objects and Barbican secrets. All endpoints except `/healthz` require a Keystone token with the `keymanager_admin` role.
 
----
+## Authentication
 
-## 🔐 Authentication (Read Me First)
-
-All endpoints require a valid **OpenStack Keystone v3** token via the HTTP header:
-
-```
-Authorization: Bearer <USER_TOKEN>
-```
-
-Internally, the service validates this token against Keystone using:
-
-- `X-Auth-Token`: the token used to **authenticate the request to Keystone** (often a service/admin token; falls back to the user token if not provided)
-- `X-Subject-Token`: the **user token being validated**
-
-### Recommended environment setup for testing
 ```bash
-export USER_TOKEN="<paste a user token>"
-export SERVICE_TOKEN="<paste a service/admin token>"   # optional
-export KEYSTONE="https://<keystone-host>:5000/v3"
+export TOKEN=$(openstack token issue -f value -c id)
 ```
 
-### 🔎 Keystone validation (optional but handy for troubleshooting)
+Pass the token as a Bearer header on every request:
+```
+Authorization: Bearer <token>
+```
 
-**A) Self-validation (no service token):**
+## Base URL
+
+```
+https://kmip.cc.<region>.cloud.sap
+```
+
+---
+
+## Endpoints
+
+### Health check
+
+```
+GET /healthz
+```
+
+No auth required. Returns `{"status": "ok"}` when the service is up.
+
 ```bash
-curl -i -s \
-  -H "X-Auth-Token: $USER_TOKEN" \
-  -H "X-Subject-Token: $USER_TOKEN" \
-  "$KEYSTONE/auth/tokens"
+curl -sk https://kmip.cc.<region>.cloud.sap/healthz | jq .
 ```
 
-**B) Service-to-service validation (privileged):**
+---
+
+### KMIP
+
+#### GET /kmip/get_kmip_id_from_barbican
+
+Returns the KMIP ID for a given Barbican secret ID.
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `barbican_id` | string | yes |
+
 ```bash
-curl -i -s \
-  -H "X-Auth-Token: $SERVICE_TOKEN" \
-  -H "X-Subject-Token: $USER_TOKEN" \
-  "$KEYSTONE/auth/tokens"
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  "https://kmip.cc.<region>.cloud.sap/kmip/get_kmip_id_from_barbican?barbican_id=2c895f23-2315-4fa6-8286-d632c88491b4" | jq .
 ```
 
-If successful, Keystone returns `200` with JSON containing `token.roles`. Your API checks these roles against `ALLOWED_ADMIN_ROLES` (default: `keymanager_admin`).
+```json
+{"kmip_id": 334}
+```
 
 ---
 
-## 🚀 **Available APIs**
+#### GET /kmip/get_barbican_id
 
-### 🔐 **Barbican APIs**
+Returns Barbican metadata for a given KMIP ID.
 
-| **HTTP Method** | **Endpoint**                          | **Description**                                               |
-|-----------------|---------------------------------------|---------------------------------------------------------------|
-| `GET`           | `/barbican/get_barbican_metadata`      | Retrieves metadata from the `secrets` table using a UUID.     |
-| `POST`          | `/barbican/update_project_id`          | Updates the `project_id` in the `secrets` table using `secret_id` and `external_id`. |
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `kmip_id` | string | yes |
 
----
-
-### 🔑 **KMIP APIs**
-
-| **HTTP Method** | **Endpoint**                           | **Description**                                                |
-|-----------------|----------------------------------------|----------------------------------------------------------------|
-| `GET`           | `/kmip/get_barbican_id`                | Retrieves Barbican metadata based on the provided KMIP ID.     |
-| `POST`          | `/kmip/kmip_register`                  | Registers a new KMIP object in the `managed_objects` table.    |
-| `GET`           | `/kmip/get_kmip_id_from_barbican`      | Retrieves the KMIP ID based on the provided Barbican ID.       |
-| `POST`          | `/kmip/update_policy`                  | Updates the policy for a given KMIP object.                    |
-| `POST`          | `/kmip/update_owner`                   | Updates the Owner for a given KMIP object.                     |
-
----
-
-## 📖 **Barbican API Documentation**
-
-### 🔎 **1. GET /barbican/get_barbican_metadata**
-
-**Description:**
-Retrieves metadata from the `secrets` table using a UUID.
-
-**Endpoint:**
-`GET /barbican/get_barbican_metadata`
-
-**Query Parameter:**
-
-| **Parameter** | **Type** | **Required** | **Description**            |
-|---------------|----------|--------------|----------------------------|
-| `uuid`        | String   | Yes          | The unique UUID of the secret. |
-
-**Example Request:**
 ```bash
-curl -s -X GET "http://<host>:5006/barbican/get_barbican_metadata?uuid=cc2ed8f9-b17b-477c-9845-fd85486a4f28" \
-  -H "Authorization: Bearer $USER_TOKEN" | jq .
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  "https://kmip.cc.<region>.cloud.sap/kmip/get_barbican_id?kmip_id=334" | jq .
 ```
 
 ---
 
-### 🔧 **2. POST /barbican/update_project_id**
+#### POST /kmip/kmip_register
 
-**Description:**
-Updates the `project_id` in the `secrets` table for a given `secret_id` and `external_id`.
-
-**Endpoint:**
-`POST /barbican/update_project_id`
-
-**Request Body:**
-
-| **Field**      | **Type** | **Required** | **Description**                 |
-|----------------|----------|--------------|---------------------------------|
-| `secret_id`    | String   | Yes          | The unique ID of the secret.    |
-| `external_id`  | String   | Yes          | The external ID of the project. |
-
-**Example Request:**
-```bash
-curl -s -X POST "http://<host>:5006/barbican/update_project_id" \
-  -H "Authorization: Bearer $USER_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"secret_id":"cc2ed8f9-b17b-477c-9845-fd85486a4f28","external_id":"e9141fb24eee4b3e9f25ae69cda31132"}' | jq .
-```
-
----
-
-## 📖 **KMIP API Documentation**
-
-### 🔎 **3. GET /kmip/get_barbican_id**
-
-**Description:**
-Retrieves Barbican metadata based on the provided KMIP ID.
-
-**Endpoint:**
-`GET /kmip/get_barbican_id`
-
-**Query Parameter:**
-
-| **Parameter** | **Type** | **Required** | **Description**         |
-|---------------|----------|--------------|-------------------------|
-| `kmip_id`     | String   | Yes          | The unique KMIP ID.     |
-
-**Example Request:**
-```bash
-curl -s -X GET "http://<host>:5006/kmip/get_barbican_id?kmip_id=1234" \
-  -H "Authorization: Bearer $USER_TOKEN" | jq .
-```
-
----
-
-### 🔧 **4. POST /kmip/kmip_register**
-
-**Description:**
 Registers a new KMIP object in the `managed_objects` table.
 
-**Endpoint:**
-`POST /kmip/kmip_register`
+| Field | Type | Required |
+|-------|------|----------|
+| `url` | string | yes |
+| `owner` | string | yes |
+| `policy` | string | yes |
 
-**Request Body:**
-
-| **Field**   | **Type** | **Required** | **Description**          |
-|-------------|----------|--------------|--------------------------|
-| `url`       | String   | Yes          | The object's URL.        |
-| `owner`     | String   | Yes          | The owner of the object. |
-| `policy`    | String   | Yes          | The policy to apply.     |
-
-**Example Request:**
 ```bash
-curl -s -X POST "http://<host>:5006/kmip/kmip_register" \
-  -H "Authorization: Bearer $USER_TOKEN" \
+curl -sk -X POST \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"url":"https://example.com/v1/secrets/e71ad2be-8708-4dcb-893d-7cb1cf22d49e","owner":"user1","policy":"default_policy"}' | jq .
+  -d '{"url": "https://example.com/key/1234", "owner": "<project-id>", "policy": "default"}' \
+  https://kmip.cc.<region>.cloud.sap/kmip/kmip_register | jq .
 ```
 
 ---
 
-### 🔎 **5. GET /kmip/get_kmip_id_from_barbican**
+#### POST /kmip/update_policy
 
-**Description:**
-Retrieves the KMIP ID based on the provided Barbican ID.
+Updates the operation policy for a KMIP object.
 
-**Endpoint:**
-`GET /kmip/get_kmip_id_from_barbican`
+| Field | Type | Required |
+|-------|------|----------|
+| `kmip_id` | string | yes |
+| `operation_policy_name` | string | yes |
 
-**Query Parameter:**
-
-| **Parameter**    | **Type** | **Required** | **Description**            |
-|------------------|----------|--------------|----------------------------|
-| `barbican_id`    | String   | Yes          | The unique Barbican ID.    |
-
-**Example Request:**
 ```bash
-curl -s -X GET "http://<host>:5006/kmip/get_kmip_id_from_barbican?barbican_id=e71ad2be-8708-4dcb-893d-7cb1cf22d49e" \
-  -H "Authorization: Bearer $USER_TOKEN" | jq .
-```
-
----
-
-### 🔧 **6. POST /kmip/update_policy**
-
-**Description:**
-Updates the policy for a given KMIP object.
-
-**Endpoint:**
-`POST /kmip/update_policy`
-
-**Request Body:**
-
-| **Field**                | **Type** | **Required** | **Description**            |
-|--------------------------|----------|--------------|----------------------------|
-| `kmip_id`                | String   | Yes          | The unique KMIP ID.        |
-| `operation_policy_name`  | String   | Yes          | The policy to be updated.  |
-
-**Example Request:**
-```bash
-curl -s -X POST "http://<host>:5006/kmip/update_policy" \
-  -H "Authorization: Bearer $USER_TOKEN" \
+curl -sk -X POST \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"kmip_id":"298","operation_policy_name":"default"}' | jq .
+  -d '{"kmip_id": "334", "operation_policy_name": "default"}' \
+  https://kmip.cc.<region>.cloud.sap/kmip/update_policy | jq .
 ```
 
 ---
 
-### 🔧 **7. POST /kmip/update_owner**
+#### POST /kmip/update_owner
 
-**Description:**
-Updates the owner for a given KMIP object.
+Updates the owner of a KMIP object.
 
-**Endpoint:**
-`POST /kmip/update_owner`
+| Field | Type | Required |
+|-------|------|----------|
+| `kmip_id` | string | yes |
+| `new_owner` | string | yes |
 
-**Request Body:**
-
-| **Field**     | **Type** | **Required** | **Description**      |
-|---------------|----------|--------------|----------------------|
-| `kmip_id`     | String   | Yes          | The unique KMIP ID.  |
-| `new_owner`   | String   | Yes          | The new owner.       |
-
-**Example Request:**
 ```bash
-curl -s -X POST "http://<host>:5006/kmip/update_owner" \
-  -H "Authorization: Bearer $USER_TOKEN" \
+curl -sk -X POST \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"kmip_id":"298","new_owner":"user2"}' | jq .
+  -d '{"kmip_id": "334", "new_owner": "<new-project-id>"}' \
+  https://kmip.cc.<region>.cloud.sap/kmip/update_owner | jq .
 ```
 
 ---
+
+### Barbican
+
+#### GET /barbican/get_barbican_metadata
+
+Returns metadata from the Barbican `secrets` table for a given UUID.
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `uuid` | string | yes |
+
+```bash
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  "https://kmip.cc.<region>.cloud.sap/barbican/get_barbican_metadata?uuid=2c895f23-2315-4fa6-8286-d632c88491b4" | jq .
+```
+
+---
+
+#### POST /barbican/update_project_id
+
+Updates the `project_id` for a given Barbican secret.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `secret_id` | string | yes |
+| `project_id` | string | yes |
+
+```bash
+curl -sk -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"secret_id": "2c895f23-2315-4fa6-8286-d632c88491b4", "project_id": "<new-project-id>"}' \
+  https://kmip.cc.<region>.cloud.sap/barbican/update_project_id | jq .
+```
+
+---
+
+## Error responses
+
+| Code | Meaning |
+|------|---------|
+| `401` | Missing/invalid token or lacks `keymanager_admin` role |
+| `400` | Missing required parameter |
+| `500` | Internal error — check `kmip-restapi` pod logs |

--- a/pykmip-restapi/app.py
+++ b/pykmip-restapi/app.py
@@ -1,36 +1,56 @@
-from flask import Flask
+import logging
+import os
+from flask import Flask, jsonify, request
+from prometheus_flask_exporter import PrometheusMetrics
 from config import AppConfig
 from routes.kmip_routes import KMIPRoutes
 from routes.barbican_routes import BarbicanRoutes
 from services.kmip_service import KMIPService
 from services.barbican_service import BarbicanService
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
 def create_app(config: AppConfig = None) -> Flask:
-    # Load config from environment if not provided
     if config is None:
         config = AppConfig.from_env()
 
-    # Create Flask app
     app = Flask(__name__)
+    PrometheusMetrics(app)
 
-    # Initialize services
+    @app.route('/healthz')
+    def healthz():
+        return jsonify({"status": "ok"})
+
+    @app.after_request
+    def log_request(response):
+        logger.info(
+            "%s %s %s -> %d",
+            request.method,
+            request.path,
+            request.remote_addr,
+            response.status_code
+        )
+        return response
+
     kmip_service = KMIPService(config.kmip_db)
     barbican_service = BarbicanService(config.barbican_db)
 
-    # Initialize and register route blueprints with prefixes
     kmip_routes = KMIPRoutes(kmip_service)
     barbican_routes = BarbicanRoutes(barbican_service)
 
-    # Register blueprints with appropriate prefixes
     app.register_blueprint(kmip_routes.bp, url_prefix='/kmip')
     app.register_blueprint(barbican_routes.bp, url_prefix='/barbican')
 
+    logger.info("Application created, routes registered.")
     return app
 
-if __name__ == "__main__":
-    # Load config from environment variables
-    config = AppConfig.from_env()
 
-    # Create and run the Flask app
+if __name__ == "__main__":
+    config = AppConfig.from_env()
     app = create_app(config)
     app.run(host=config.host, port=config.port, debug=config.debug)

--- a/pykmip-restapi/requirements.txt
+++ b/pykmip-restapi/requirements.txt
@@ -1,6 +1,9 @@
-Flask==2.3.2
+Flask==3.0.3
+Werkzeug>=3.0.3,<4.0
 PyKMIP==0.10.0
 gunicorn==23.0.0
 cryptography==43.0.1
 pymysql==1.1.1
 mysql-connector-python==9.1.0
+prometheus-flask-exporter==0.23.1
+requests>=2.31.0,<3.0

--- a/pykmip-restapi/routes/barbican_routes.py
+++ b/pykmip-restapi/routes/barbican_routes.py
@@ -1,15 +1,15 @@
 from flask import Blueprint, request, jsonify
+import logging
 import requests
 import os
 
+logger = logging.getLogger(__name__)
+
+
 def is_authorized(request):
-    """
-    Validate Bearer token against Keystone v3 and ensure it has an allowed role.
-    Minimal logging: only emit concise error reasons.
-    """
-    keystone_url = os.environ.get("keystone_url")  # e.g., https://keystone:5000/v3
+    keystone_url = os.environ.get("keystone_url")
     if not keystone_url:
-        print("[Auth] Missing env keystone_url")
+        logger.error("Keystone URL not set")
         return False
 
     allowed_roles = {
@@ -18,7 +18,7 @@ def is_authorized(request):
 
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
-        print("[Auth] Missing/invalid Authorization header")
+        logger.warning("Missing or invalid Authorization header from %s", request.remote_addr)
         return False
 
     subject_token = auth_header.split("Bearer ", 1)[1].strip()
@@ -32,24 +32,26 @@ def is_authorized(request):
     url = keystone_url.rstrip("/") + "/auth/tokens"
 
     try:
+        logger.debug("Validating token against Keystone: %s", keystone_url)
         resp = requests.get(url, headers=headers, timeout=10)
         if resp.status_code != 200:
-            print(f"[Auth] Keystone {resp.status_code}")
+            logger.warning("Keystone returned %d for %s", resp.status_code, request.remote_addr)
             return False
 
         token = resp.json().get("token", {})
         role_names = {r.get("name") for r in token.get("roles", []) if isinstance(r, dict)}
         if not (allowed_roles & role_names):
-            print(f"[Auth] Missing required role. Needed one of {sorted(allowed_roles)}; got {sorted(role_names)}")
+            logger.warning("Token from %s lacks required role. Needed one of %s; got %s",
+                           request.remote_addr, sorted(allowed_roles), sorted(role_names))
             return False
         return True
 
     except requests.exceptions.RequestException as e:
-        print(f"[Auth] Keystone request error: {e}")
+        logger.error("Keystone request error: %s", e)
     except ValueError:
-        print("[Auth] Bad JSON from Keystone")
+        logger.error("Bad JSON from Keystone")
     except Exception as e:
-        print(f"[Auth] Unexpected: {e}")
+        logger.error("Unexpected error during token validation: %s", e, exc_info=True)
 
     return False
 
@@ -67,24 +69,21 @@ class BarbicanRoutes:
     def get_metadata(self):
         if not is_authorized(request):
             return jsonify({"error": "Unauthorized"}), 401
-
         uuid = request.args.get('uuid')
         if not uuid:
             return jsonify({"error": "Missing uuid"}), 400
-
+        logger.info("get_barbican_metadata called with uuid=%s", uuid)
         result = self.barbican_service.get_metadata_from_uuid(uuid)
         return jsonify(result)
 
     def update_project_id(self):
         if not is_authorized(request):
             return jsonify({"error": "Unauthorized"}), 401
-
         data = request.get_json() or {}
         secret_id = data.get('secret_id')
         project_id = data.get('project_id')
-
         if not secret_id or not project_id:
             return jsonify({"error": "Missing parameters"}), 400
-
+        logger.info("update_project_id called with secret_id=%s project_id=%s", secret_id, project_id)
         result = self.barbican_service.update_project_id(secret_id, project_id)
         return jsonify(result)

--- a/pykmip-restapi/routes/kmip_routes.py
+++ b/pykmip-restapi/routes/kmip_routes.py
@@ -4,14 +4,13 @@ import logging
 import requests
 import os
 
+logger = logging.getLogger(__name__)
+
+
 def is_authorized(request):
-    """
-    Validate Bearer token against Keystone v3 and ensure it has an allowed role.
-    Minimal logging: only emit concise error reasons.
-    """
-    keystone_url = os.environ.get("keystone_url")  # e.g., https://keystone:5000/v3
+    keystone_url = os.environ.get("keystone_url")
     if not keystone_url:
-        print("[Auth] Missing env keystone_url")
+        logger.error("Keystone URL not set")
         return False
 
     allowed_roles = {
@@ -20,7 +19,7 @@ def is_authorized(request):
 
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
-        print("[Auth] Missing/invalid Authorization header")
+        logger.warning("Missing or invalid Authorization header from %s", request.remote_addr)
         return False
 
     subject_token = auth_header.split("Bearer ", 1)[1].strip()
@@ -34,24 +33,26 @@ def is_authorized(request):
     url = keystone_url.rstrip("/") + "/auth/tokens"
 
     try:
+        logger.debug("Validating token against Keystone: %s", keystone_url)
         resp = requests.get(url, headers=headers, timeout=10)
         if resp.status_code != 200:
-            print(f"[Auth] Keystone {resp.status_code}")
+            logger.warning("Keystone returned %d for %s", resp.status_code, request.remote_addr)
             return False
 
         token = resp.json().get("token", {})
         role_names = {r.get("name") for r in token.get("roles", []) if isinstance(r, dict)}
         if not (allowed_roles & role_names):
-            print(f"[Auth] Missing required role. Needed one of {sorted(allowed_roles)}; got {sorted(role_names)}")
+            logger.warning("Token from %s lacks required role. Needed one of %s; got %s",
+                           request.remote_addr, sorted(allowed_roles), sorted(role_names))
             return False
         return True
 
     except requests.exceptions.RequestException as e:
-        print(f"[Auth] Keystone request error: {e}")
+        logger.error("Keystone request error: %s", e)
     except ValueError:
-        print("[Auth] Bad JSON from Keystone")
+        logger.error("Bad JSON from Keystone")
     except Exception as e:
-        print(f"[Auth] Unexpected: {e}")
+        logger.error("Unexpected error during token validation: %s", e, exc_info=True)
 
     return False
 
@@ -72,25 +73,22 @@ class KMIPRoutes:
     def get_barbican_id(self):
         if not is_authorized(request):
             return jsonify({"error": "Unauthorized"}), 401
-
         kmip_id = request.args.get('kmip_id')
         if not kmip_id:
             return jsonify({"error": "Missing kmip_id"}), 400
-
+        logger.info("get_barbican_id called with kmip_id=%s", kmip_id)
         result = self.kmip_service.execute_mysql_queries(kmip_id)
         return jsonify(result)
 
     def update_policy(self):
         if not is_authorized(request):
             return jsonify({"error": "Unauthorized"}), 401
-
         data = request.get_json() or {}
         kmip_id = data.get('kmip_id')
         operation_policy_name = data.get('operation_policy_name')
-
         if not kmip_id or not operation_policy_name:
             return jsonify({"error": "Missing required parameters: 'kmip_id' and 'operation_policy_name'"}), 400
-
+        logger.info("update_policy called with kmip_id=%s policy=%s", kmip_id, operation_policy_name)
         try:
             result = self.kmip_service.execute_mysql_queries(kmip_id, operation_policy_name=operation_policy_name)
             if "error" in result:
@@ -101,47 +99,42 @@ class KMIPRoutes:
                 "updated_policy": operation_policy_name,
                 "details": result
             }), 200
-        except Exception:
-            logging.error("Unexpected error in update_policy", exc_info=True)
-            return jsonify({"error": "An internal error has occurred. Please contact support."}), 500
+        except Exception as e:
+            logger.error("Unexpected error in update_policy: %s", e, exc_info=True)
+            return jsonify({"error": "An internal error has occurred."}), 500
 
     def register_kmip(self):
         if not is_authorized(request):
             return jsonify({"error": "Unauthorized"}), 401
-
         data = request.get_json() or {}
         url = data.get('url')
         owner = data.get('owner')
         policy = data.get('policy')
-
         if not url or not owner or not policy:
             return jsonify({"error": "Missing parameters"}), 400
-
+        logger.info("kmip_register called with owner=%s policy=%s", owner, policy)
         result = self.kmip_service.register_kmip_object(url, owner, policy)
         return jsonify(result)
 
     def get_kmip_id_from_barbican(self):
         if not is_authorized(request):
             return jsonify({"error": "Unauthorized"}), 401
-
         barbican_id = request.args.get('barbican_id')
         if not barbican_id:
             return jsonify({"error": "Missing barbican_id"}), 400
-
+        logger.info("get_kmip_id_from_barbican called with barbican_id=%s", barbican_id)
         result = self.kmip_service.get_kmip_id_from_barbican(barbican_id)
         return jsonify(result)
 
     def update_owner(self):
         if not is_authorized(request):
             return jsonify({"error": "Unauthorized"}), 401
-
         data = request.get_json() or {}
         kmip_id = data.get('kmip_id')
         new_owner = data.get('new_owner')
-
         if not kmip_id or not new_owner:
             return jsonify({"error": "Missing required parameters: 'kmip_id' and 'new_owner'"}), 400
-
+        logger.info("update_owner called with kmip_id=%s new_owner=%s", kmip_id, new_owner)
         try:
             result = self.kmip_service.execute_mysql_queries(kmip_id, owner=new_owner)
             if "error" in result:
@@ -151,6 +144,6 @@ class KMIPRoutes:
                 "kmip_id": kmip_id,
                 "new_owner": new_owner
             }), 200
-        except Exception:
-            logging.error("Unexpected error in update_owner", exc_info=True)
-            return jsonify({"error": "An internal error has occurred. Please contact support."}), 500
+        except Exception as e:
+            logger.error("Unexpected error in update_owner: %s", e, exc_info=True)
+            return jsonify({"error": "An internal error has occurred."}), 500

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ python-openstackclient
 requests
 flask
 six>=1.11.0
-sqlalchemy>=1.0
+sqlalchemy>=1.0,<2.1

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
         "python-openstackclient",
         "requests",
         "six",
-        "sqlalchemy"
+        "sqlalchemy>=1.0,<2.1"
     ],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
Replace app credentials with service user auth, add logging, healthz endpoint, TCP health listener, Flask 3.x upgrade